### PR TITLE
Fix stat of total results error.

### DIFF
--- a/stats/service.go
+++ b/stats/service.go
@@ -174,7 +174,7 @@ func (svc *Service) getOverviewResults(query bson.M) (data interface{}, err erro
 			"$group",
 			bson.M{
 				"_id":     nil,
-				"results": bson.M{"$sum": "$rc"},
+				"results": bson.M{"$sum": "$result_count"},
 			},
 		}},
 	}


### PR DESCRIPTION
解决最新v0.6版本的统计结果总数页面，取的mongo统计字段不对导致显示0的问题。