### PR TITLE
perf(runner): close fs service client when task finished && batch writing logs

### DIFF
--- a/interfaces/task_runner.go
+++ b/interfaces/task_runner.go
@@ -12,4 +12,5 @@ type TaskRunner interface {
 	Dispose() (err error)
 	SetSubscribeTimeout(timeout time.Duration)
 	GetTaskId() (id primitive.ObjectID)
+	CleanUp() (err error)
 }

--- a/task/handler/runner.go
+++ b/task/handler/runner.go
@@ -199,6 +199,19 @@ func (r *Runner) Dispose() (err error) {
 	}, backoff.NewExponentialBackOff())
 }
 
+// CleanUp clean up task runner
+func (r *Runner) CleanUp() (err error) {
+	// close fs service
+	fsSvc := r.fsSvc.GetFsService().GetFs()
+	if fsSvc == nil {
+		return
+	}
+	if err = fsSvc.Close(); err != nil {
+		return
+	}
+	return
+}
+
 func (r *Runner) SetSubscribeTimeout(timeout time.Duration) {
 	r.subscribeTimeout = timeout
 }

--- a/task/handler/runner.go
+++ b/task/handler/runner.go
@@ -55,6 +55,7 @@ type Runner struct {
 	// log internals
 	scannerStdout *bufio.Scanner
 	scannerStderr *bufio.Scanner
+	logBatchSize  int
 }
 
 func (r *Runner) Init() (err error) {
@@ -267,10 +268,20 @@ func (r *Runner) startLogging() {
 
 func (r *Runner) startLoggingReaderStdout() {
 	utils.LogDebug("begin startLoggingReaderStdout")
+	var lines []string
 	for r.scannerStdout.Scan() {
 		line := r.scannerStdout.Text()
-		utils.LogDebug(fmt.Sprintf("scannerStdout line: %s", line))
-		r.writeLogLine(line)
+		lines = append(lines, line)
+		if len(lines) >= r.logBatchSize {
+			r.writeLogLines(lines)
+			utils.LogDebug(fmt.Sprintf("scannerStdout lines: %s", lines))
+			lines = []string{}
+		}
+	}
+	if len(lines) > 0 {
+		r.writeLogLines(lines)
+		utils.LogDebug(fmt.Sprintf("scannerStdout lines: %s", lines))
+
 	}
 	// reach end
 	utils.LogDebug("scannerStdout reached end")
@@ -278,10 +289,19 @@ func (r *Runner) startLoggingReaderStdout() {
 
 func (r *Runner) startLoggingReaderStderr() {
 	utils.LogDebug("begin startLoggingReaderStderr")
+	var lines []string
 	for r.scannerStderr.Scan() {
 		line := r.scannerStderr.Text()
-		utils.LogDebug(fmt.Sprintf("scannerStderr line: %s", line))
-		r.writeLogLine(line)
+		lines = append(lines, line)
+		if len(lines) >= r.logBatchSize {
+			r.writeLogLines(lines)
+			utils.LogDebug(fmt.Sprintf("scannerStderr lines: %s", lines))
+			lines = []string{}
+		}
+	}
+	if len(lines) > 0 {
+		r.writeLogLines(lines)
+		utils.LogDebug(fmt.Sprintf("scannerStderr lines: %s", lines))
 	}
 	// reach end
 	utils.LogDebug("scannerStderr reached end")
@@ -468,10 +488,10 @@ func (r *Runner) initSub() (err error) {
 	return nil
 }
 
-func (r *Runner) writeLogLine(line string) {
+func (r *Runner) writeLogLines(lines []string) {
 	data, err := json.Marshal(&entity.StreamMessageTaskData{
 		TaskId: r.tid,
-		Logs:   []string{line},
+		Logs:   lines,
 	})
 	if err != nil {
 		trace.PrintError(err)
@@ -586,6 +606,7 @@ func NewTaskRunner(id primitive.ObjectID, svc interfaces.TaskHandlerService, opt
 		svc:              svc,
 		tid:              id,
 		ch:               make(chan constants.TaskSignal),
+		logBatchSize:     20,
 	}
 
 	// apply options

--- a/task/handler/service.go
+++ b/task/handler/service.go
@@ -376,7 +376,12 @@ func (svc *Service) run(taskId primitive.ObjectID) (err error) {
 	go func() {
 		// delete runner from pool
 		defer svc.deleteRunner(r.GetTaskId())
-
+		defer func(r interfaces.TaskRunner) {
+			err := r.CleanUp()
+			if err != nil {
+				log.Errorf("task[%s] clean up error: %v", r.GetTaskId().Hex(), err)
+			}
+		}(r)
 		// run task process (blocking)
 		// error or finish after task runner ends
 		if err := r.Run(); err != nil {


### PR DESCRIPTION
### runner 新增 CleanUp，以关闭SeaweedFsManager
<img width="1285" alt="image" src="https://user-images.githubusercontent.com/38464007/230095805-2264b718-f26d-4086-825f-720be99f7565.png">

本地调试时发现随着任务的执行，goroutine会随着任务数不断地增长，得不到释放，其中大部分的goroutine都集中在一个wroker-pool，实际是goseaweed的worker pool
初步断定是当任务执行时会start一个SeaweedFsManager，但当任务执行结束时却并没有调用close方法，将其close掉引起的


### runner 修改日志的写入方式，改为批量写入，以减少file 的频繁打开与关闭

