### PR TITLE
对Crawlab v0.6.2 docker部署时发现的/var/log/crawlab不存在异常的修复

### DIFF
--- a/task/log/file_driver.go
+++ b/task/log/file_driver.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"github.com/apex/log"
 	"github.com/crawlab-team/crawlab-core/utils"
-	"github.com/crawlab-team/go-trace"
 	"github.com/spf13/viper"
 	"io"
 	"os"
@@ -178,7 +177,13 @@ func (d *FileLogDriver) lineCounter(r io.Reader) (n int, err error) {
 
 func (d *FileLogDriver) cleanup() {
 	for {
-		dirs := utils.ListDir(d.opts.BaseDir)
+		// 增加对目录不存在的判断
+		// dirs, _ := utils.ListDir(d.opts.BaseDir)
+		dirs, err := utils.ListDir(d.opts.BaseDir)
+		if err != nil {
+			trace.PrintError(err)
+			break
+		}
 		for _, dir := range dirs {
 			if time.Now().After(dir.ModTime().Add(d.opts.Ttl)) {
 				if err := os.RemoveAll(d.getBasePath(dir.Name())); err != nil {

--- a/task/log/file_driver.go
+++ b/task/log/file_driver.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"github.com/apex/log"
 	"github.com/crawlab-team/crawlab-core/utils"
+	"github.com/crawlab-team/go-trace"
 	"github.com/spf13/viper"
 	"io"
 	"os"
@@ -145,7 +146,13 @@ func (d *FileLogDriver) getLogFilePath(id, fileName string) (filePath string) {
 }
 
 func (d *FileLogDriver) getLogFiles(id string) (files []os.FileInfo) {
-	return utils.ListDir(d.getBasePath(id))
+	// 增加了对返回异常的捕获
+	files, err := utils.ListDir(d.getBasePath(id))
+	if err != nil {
+		trace.PrintError(err)
+		return nil
+	}
+	return
 }
 
 func (d *FileLogDriver) initDir(id string) {

--- a/utils/file.go
+++ b/utils/file.go
@@ -78,15 +78,18 @@ func IsDir(path string) bool {
 	return s.IsDir()
 }
 
-func ListDir(path string) []os.FileInfo {
+// ListDir Add: 增加error类型作为第二返回值
+// 在其他函数如 /task/log/file_driver.go中的 *FileLogDriver.cleanup()函数调用时
+// 可以通过判断err是否为nil来判断是否有错误发生
+func ListDir(path string) ([]os.FileInfo, error) {
 	list, err := ioutil.ReadDir(path)
 	if err != nil {
 		log.Errorf(err.Error())
 		debug.PrintStack()
-		return nil
+		return nil, err
 	}
-	return list
-}
+	return list, nil
+}s
 
 func IsFile(path string) bool {
 	return !IsDir(path)
@@ -183,9 +186,9 @@ func DeCompress(srcFile *os.File, dstPath string) error {
 	return nil
 }
 
-//压缩文件
-//files 文件数组，可以是不同dir下的文件或者文件夹
-//dest 压缩文件存放地址
+// 压缩文件
+// files 文件数组，可以是不同dir下的文件或者文件夹
+// dest 压缩文件存放地址
 func Compress(files []*os.File, dest string) error {
 	d, _ := os.Create(dest)
 	defer Close(d)

--- a/utils/file.go
+++ b/utils/file.go
@@ -89,7 +89,7 @@ func ListDir(path string) ([]os.FileInfo, error) {
 		return nil, err
 	}
 	return list, nil
-}s
+}
 
 func IsFile(path string) bool {
 	return !IsDir(path)
@@ -251,7 +251,13 @@ func _Compress(file *os.File, prefix string, zw *zip.Writer) error {
 
 func GetFilesFromDir(dirPath string) ([]*os.File, error) {
 	var res []*os.File
-	for _, fInfo := range ListDir(dirPath) {
+	// 增加了返回异常的捕获及处理
+	t, err := ListDir(dirPath)
+	if err != nil {
+		debug.PrintStack()
+		return nil, err
+	}
+	for _, fInfo := range t {
 		f, err := os.Open(filepath.Join(dirPath, fInfo.Name()))
 		if err != nil {
 			return res, err


### PR DESCRIPTION
1. 修改: /task/log/file_driver.go中的cleanup()对调用utils.ListDir()函数的异常捕获。
2. 增加: /utils/file.go中的ListDir()新增了第二返回值error类型。