### PR TITLE
fix: disable dedup when the dedup field is not set

### DIFF
--- a/result/service_mongo.go
+++ b/result/service_mongo.go
@@ -1,6 +1,8 @@
 package result
 
 import (
+	"time"
+
 	"github.com/crawlab-team/crawlab-core/constants"
 	"github.com/crawlab-team/crawlab-core/interfaces"
 	"github.com/crawlab-team/crawlab-core/models/models"
@@ -13,7 +15,6 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	mongo2 "go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
-	"time"
 )
 
 type ServiceMongo struct {
@@ -39,7 +40,7 @@ func (svc *ServiceMongo) Count(query generic.ListQuery) (n int, err error) {
 }
 
 func (svc *ServiceMongo) Insert(docs ...interface{}) (err error) {
-	if svc.dc.Dedup.Enabled {
+	if svc.dc.Dedup.Enabled && len(svc.dc.Dedup.Keys) > 0 {
 		for _, doc := range docs {
 			hash, err := utils.GetResultHash(doc, svc.dc.Dedup.Keys)
 			if err != nil {


### PR DESCRIPTION
In order to avoid incorrect operation click, if the user does not set the deduplication field, according to the logic here, there will always be only one piece of data.